### PR TITLE
fixing takeUntil, dropUntil, and Deep.split

### DIFF
--- a/src/fingertree.js
+++ b/src/fingertree.js
@@ -136,7 +136,7 @@
 
   /**
    * Split the digit into 3 parts, in which the left part is the elements
-   * that does not satisfy the predicate, the middle part is the first 
+   * that do not satisfy the predicate, the middle part is the first 
    * element that satisfies the predicate and the last part is the rest
    * elements.
    * @param {Function} predicate A function which returns either true or false
@@ -293,17 +293,17 @@
 
   /**
    * Split the tree into two halves, where the first half is a finger-tree
-   * which contains all the elements that satisfy the given predicate,
-   * while the ones from the other half do not.
+   * which contains all the elements that do not satisfy the given predicate,
+   * while the ones from the other half do.
    * @param {function(*): boolean} predicate
    * @return {Array.<FingerTree>} An array with the first element being a
-   *   finger-tree that contains all the satisfying elements and the second
+   *   finger-tree that contains all the nonsatisfying elements and the second
    *   element being a finger-tree that contains all the other elements.
    */
   FingerTree.prototype.split = notImplemented;
 
   /**
-   * Take elements from the tree until the predicate is returning false.
+   * Take elements from the tree until the predicate returns true.
    * @param {function(*): boolean} predicate
    * @return {FingerTree}
    */
@@ -312,7 +312,7 @@
   };
 
   /**
-   * Drop elements from the tree until the predicate is returning false.
+   * Drop elements from the tree until the predicate is returns true.
    * @param {function(*): boolean} predicate
    * @return {FingerTree}
    */
@@ -514,9 +514,9 @@
    */
   Single.prototype.split = function (predicate) {
     if (predicate(this.measure())) {
-      return [this, new Empty(this.measurer)];
+        return [new Empty(this.measurer), this];
     }
-    return [new Empty(this.measurer), this];
+    return [this, new Empty(this.measurer)];
   };
 
   /**

--- a/test/fingertree.test.js
+++ b/test/fingertree.test.js
@@ -198,15 +198,15 @@ describe('Finger Tree', function () {
     split = tree.split(function (x) {
       return x > 0;
     });
-    split[0].measure().should.eql(1);
-    split[1].isEmpty().should.be.true;
+    split[0].isEmpty().should.be.true;
+    split[1].measure().should.eql(1);
 
     tree = FingerTree.fromArray([1]);
     split = tree.split(function (x) {
       return x > 1;
     });
-    split[0].isEmpty().should.be.true;
-    split[1].measure().should.eql(1);
+    split[0].measure().should.eql(1);
+    split[1].isEmpty().should.be.true;
 
     tree = FingerTree.fromArray(range(100));
     split = tree.split(function (x) {


### PR DESCRIPTION
OK, I'm pretty confident in this one.  According to the comment, split should return all of the items from the start that satisfy predicate.

Here's the old code:
coffee> ft=require './src/fingertree'
{ [Function: FingerTree] fromArray: [Function: fromArray] }
coffee> ft.fromArray([1]).split((x)->x < 3)[0].peekLast()
1
coffee> ft.fromArray([1,2]).split((x)->x < 3)[0].peekLast()
null
coffee> ft.fromArray([1,2,3]).split((x)->x < 3)[0].peekLast()
3


Here's the new code:
coffee> ft=require './src/fingertree'
{ [Function: FingerTree] fromArray: [Function: fromArray] }
coffee> ft.fromArray([1]).split((x)->x < 3)[0].peekLast()
1
coffee> ft.fromArray([1,2]).split((x)->x < 3)[0].peekLast()
2
coffee> ft.fromArray([1,2,3]).split((x)->x < 3)[0].peekLast()
2
